### PR TITLE
Add .travis.yaml (travis-ci.org) for Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,11 @@ matrix:
       env: TOXENV=nightly
     - python: "3.5"
       env: TOXENV=checkers
+    - python: "3.6"
+      env: ENV=dev
     allow_failures:
     - env: TOXENV=nightly
+    - env: ENV=dev
 install:
 - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then pip3 install tox; fi
 - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then pip3 install -r requirements.txt; fi
@@ -28,6 +31,7 @@ install:
 - if [[ $TOXENV == 'py35' ]]; then pip install coveralls; fi
 script:
 - if [[ ! -z $TOXENV ]]; then tox -e $TOXENV; fi
+- if [[ $ENV == 'dev' ]]; then tox -e py36 -c tox-dev.ini; fi
 after_success:
 - if [[ $TOXENV == 'py35' ]]; then coveralls; fi
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 sudo: false
 language: python
-branches:
-    only:
-    - dev
-    - v0.1.3
 matrix:
     include:
     - os: osx
@@ -30,9 +26,7 @@ install:
 - if [[ $TOXENV == 'checkers' ]]; then pip install flake8; fi
 - if [[ $TOXENV == 'checkers' ]]; then pip install pep8-naming; fi
 - if [[ $TOXENV == 'py35' ]]; then pip install coveralls; fi
-- if [[ $TRAVIS_PULL_REQUEST != 'false' ]]; then pip install yapf; fi
 script:
-- if [[ $TRAVIS_PULL_REQUEST != 'false' ]] && [[ $TOXENV == 'checkers' ]]; then yapf -i isbnlib_porbase; fi
 - if [[ ! -z $TOXENV ]]; then tox -e $TOXENV; fi
 after_success:
 - if [[ $TOXENV == 'py35' ]]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+sudo: false
+language: python
+branches:
+    only:
+    - dev
+    - v0.1.3
+matrix:
+    include:
+    - os: osx
+      language: generic
+      env: TOXENV=py36
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "nightly"
+      env: TOXENV=nightly
+    - python: "3.5"
+      env: TOXENV=checkers
+    allow_failures:
+    - env: TOXENV=nightly
+install:
+- if [[ $TRAVIS_OS_NAME == 'osx' ]]; then pip3 install tox; fi
+- if [[ $TRAVIS_OS_NAME == 'osx' ]]; then pip3 install -r requirements.txt; fi
+- if [[ $TRAVIS_OS_NAME == 'linux' ]]; then pip install tox; fi
+- if [[ $TRAVIS_OS_NAME == 'linux' ]]; then pip install -r requirements.txt; fi
+- if [[ $TOXENV == 'checkers' ]]; then pip install -r requirements.txt; fi
+- if [[ $TOXENV == 'checkers' ]]; then pip install flake8; fi
+- if [[ $TOXENV == 'checkers' ]]; then pip install pep8-naming; fi
+- if [[ $TOXENV == 'py35' ]]; then pip install coveralls; fi
+- if [[ $TRAVIS_PULL_REQUEST != 'false' ]]; then pip install yapf; fi
+script:
+- if [[ $TRAVIS_PULL_REQUEST != 'false' ]] && [[ $TOXENV == 'checkers' ]]; then yapf -i isbnlib_porbase; fi
+- if [[ ! -z $TOXENV ]]; then tox -e $TOXENV; fi
+after_success:
+- if [[ $TOXENV == 'py35' ]]; then coveralls; fi
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/tox-dev.ini
+++ b/tox-dev.ini
@@ -1,0 +1,32 @@
+[flake8]
+ignore=N806,I100,I101,I201,N802,C901,E722,E741
+exclude=*/test/*
+max-complexity=10
+
+[pep257]
+ignore=D203
+
+[tox]
+envlist=py27,py35,py36,nightly,checkers
+
+[testenv]
+deps=
+    nose
+    coverage
+    https://github.com/xlcnd/isbnlib/archive/dev.zip
+commands=
+    nosetests -v --with-coverage --cover-package=isbnlib_mcues --cover-min-percentage=90
+    python -c "from isbnlib_mcues import query;print(query('9788437604947'))"
+
+[testenv:checkers]
+basepython=python3.5
+deps=
+    isbnlib
+    flake8
+    flake8-bugbear
+    flake8-commas
+    flake8-docstrings
+    flake8-import-order
+    pep8-naming
+commands=
+    flake8 isbnlib_mcues

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,32 @@
 [flake8]
 ignore=N806,I100,I101,I201,N802,C901,E722,E741
 exclude=*/test/*
-max-complexity=13
+max-complexity=10
 
 [pep257]
 ignore=D203
 
 [tox]
-envlist=py27,py35
+envlist=py27,py35,py36,nightly,checkers
 
 [testenv]
 deps=
     nose
+    coverage
     isbnlib
 commands=
-    nosetests -v
-    python -c "from isbnlib_mcues import query;print(query('9788491043508'))"
+    nosetests -v --with-coverage --cover-package=isbnlib_mcues --cover-min-percentage=90
+    python -c "from isbnlib_porbase import query;print(query('9789727228164'))"
+
+[testenv:checkers]
+basepython=python3.5
+deps=
+    isbnlib
+    flake8
+    flake8-bugbear
+    flake8-commas
+    flake8-docstrings
+    flake8-import-order
+    pep8-naming
+commands=
+    flake8 isbnlib_mcues


### PR DESCRIPTION
I add more sophisticated tests in tox.ini and add a configuration file for travis CI. You will be able to do a wide range of tests automatically in travis.

NOTE: You have to create a free account on **travis-ci.org** and give authorization to link to github, after that no more work...!

Please, fell free to rejects this PR if you don't want this layer of complexity.